### PR TITLE
fixes missing stubs in addNames.r2 script

### DIFF
--- a/blutter/src/DartDumper.cpp
+++ b/blutter/src/DartDumper.cpp
@@ -135,6 +135,20 @@ void DartDumper::Dump4Radare2(std::filesystem::path outDir)
 		}
 		show_library = true;
 	}
+	for (auto& item : app.stubs) {
+		auto stub = item.second;
+		const auto ep = stub->Address();
+		auto name = stub->FullName();
+		std::replace(name.begin(), name.end(), '<', '_');
+		std::replace(name.begin(), name.end(), '>', '_');
+		std::replace(name.begin(), name.end(), ',', '_');
+		std::replace(name.begin(), name.end(), ' ', '_');
+		std::replace(name.begin(), name.end(), '$', '_');
+		std::replace(name.begin(), name.end(), '&', '_');
+		std::replace(name.begin(), name.end(), '-', '_');
+		std::replace(name.begin(), name.end(), '+', '_');
+		of << std::format("f method.{}={:#x}\n", name.c_str(), ep);
+	}
 }
 
 void DartDumper::Dump4Ida(std::filesystem::path outDir)


### PR DESCRIPTION
Radare2 script was missing a few methods such as 

```
   // 0x2c544c: r0 = StackOverflowSharedWithoutFPURegs()
    //     0x2c544c: bl              #0x2c2b9c  ; StackOverflowSharedWithoutFPURegsStub
    // 0x2c5450: b               #0x2c5438
```

This fixes it and adds it to `addNames.r2`:

```
f method.StackOverflowSharedWithoutFPURegsStub=0x2c2b9c
```